### PR TITLE
fix sent invitations screen

### DIFF
--- a/by-email/by-email-db.php
+++ b/by-email/by-email-db.php
@@ -147,9 +147,9 @@ class Invite_Anyone_Schema {
 		), $this ) );
 
 		// Stash in $bp because of template tags that need it
-                if ( !isset( $bp->invite_anyone ) ) {
-                        $bp->invite_anyone = new stdClass;
-                }
+		if ( !isset( $bp->invite_anyone ) ) {
+			$bp->invite_anyone = new stdClass;
+		}
 
 		$bp->invite_anyone->invitee_tax_name = $this->invitee_tax_name;
 		$bp->invite_anyone->invited_groups_tax_name = $this->invited_groups_tax_name;

--- a/by-email/by-email.php
+++ b/by-email/by-email.php
@@ -48,7 +48,10 @@ add_action( 'wp_print_scripts', 'invite_anyone_add_by_email_js' );
 function invite_anyone_setup_globals() {
 	global $bp, $wpdb;
 
-	$bp->invite_anyone = new stdClass;
+	if ( !isset( $bp->invite_anyone ) ) {
+		$bp->invite_anyone = new stdClass;
+	}
+
 	$bp->invite_anyone->id = 'invite_anyone';
 
 	$bp->invite_anyone->table_name = $wpdb->base_prefix . 'bp_invite_anyone';


### PR DESCRIPTION
Avoiding the PHP warning in 19b065ca8e4838658a83eb98da4f761f5cb08a6f has accidentally broken the "Sent Invitations" list, because `invite_anyone_setup_globals()` runs after `Invite_Anyone_Schema::register_post_type()` on `invite_anyone_screen_two()` and inadvertently clears `$bp->invite_anyone->invitee_tax_name` and `$bp->invite_anyone->invited_groups_tax_name`.
