### PR TITLE
Workaround for plus signs in email addresses

### DIFF
--- a/admin/admin-panel.php
+++ b/admin/admin-panel.php
@@ -516,7 +516,9 @@ function invite_anyone_settings_mi_content() {
 					$emails = wp_get_post_terms( get_the_ID(), invite_anyone_get_invitee_tax_name() );
 
 					foreach( $emails as $email ) {
-						echo esc_html( $email->name );
+						// Before storing taxonomy terms in the db, we replace "+" with ".PLUSSIGN.", so we need to reverse that before displaying the email address.
+						$email_address	= str_replace( '.PLUSSIGN.', '+', $email->name );
+						echo esc_html( $email_address );
 					}
 					?>
 				</td>

--- a/by-email/by-email-db.php
+++ b/by-email/by-email-db.php
@@ -573,6 +573,10 @@ class Invite_Anyone_Invitation {
  * @param bool $is_cloudsponge Did this email address originate with CloudSponge?
  */
 function invite_anyone_record_invitation( $inviter_id, $email, $message, $groups, $subject = false, $is_cloudsponge = false ) {
+
+	// hack to make sure that gmail + email addresses work
+	$email	= str_replace( '+', '.PLUSSIGN.', $email );
+	
 	$args = array(
 		'inviter_id' 	 => $inviter_id,
 		'invitee_email'	 => $email,
@@ -624,7 +628,10 @@ function invite_anyone_get_invitations_by_inviter_id( $inviter_id, $orderby = fa
  */
 function invite_anyone_get_invitations_by_invited_email( $email ) {
 	// hack to make sure that gmail + email addresses work
+	// If the url takes the form register/accept-invitation/username+extra%40gmail.com, urldecode returns a space in place of the +. (This is not typical, but we can catch it.)
 	$email	= str_replace( ' ', '+', $email );
+	// More common: url takes the form register/accept-invitation/username%2Bextra%40gmail.com, so we grab the + that urldecode returns and replace it to create a usable search term.
+	$email	= str_replace( '+', '.PLUSSIGN.', $email );
 
 	$args = array(
 		'invitee_email'	=> $email,

--- a/by-email/by-email.php
+++ b/by-email/by-email.php
@@ -765,7 +765,8 @@ function invite_anyone_screen_two() {
 						continue;
 					}
 
-					$email	= $emails[0]->name;
+					// Before storing taxonomy terms in the db, we replaced "+" with ".PLUSSIGN.", so we need to reverse that before displaying the email address.
+					$email	= str_replace( '.PLUSSIGN.', '+', $emails[0]->name );
 
 					$post_id = get_the_ID();
 


### PR DESCRIPTION
Gmail email addresses containing plus signs cause problems with
taxonomy terms and taxonomy searching. This fix stores + as .PLUSSIGN.
in the database as a workaround.
