### PR TITLE
Use bp_locate_template to find best template to use

### DIFF
--- a/group-invites/group-invites.php
+++ b/group-invites/group-invites.php
@@ -168,7 +168,7 @@ function invite_anyone_catch_group_invites() {
 add_action( 'wp', 'invite_anyone_catch_group_invites', 1 );
 
 function invite_anyone_create_screen_content( $event ) {
-	if ( !$template = bp_locate_template( 'groups/single/invite-anyone.php', true ) ) {
+	if ( !$template = function_exists( 'bp_locate_template' ) ? bp_locate_template( 'groups/single/invite-anyone.php', true ) : locate_template( 'groups/single/invite-anyone.php', true ) ) {
 		include_once( 'templates/invite-anyone.php' );
 	}
 }


### PR DESCRIPTION
I noticed that my custom template file was being ignored after reorganizing my theme in the post-BP1.8 format.

Commit note: bp_locate_template() searches old template structure (/groups/, etc, at root of theme) and new style (/groups/, etc, in /buddypress/ or /community/ folder at root of theme). Does require BP 1.7+, though.
