### PR TITLE
Submit button state management

### DIFF
--- a/group-invites/group-invites-js.js
+++ b/group-invites/group-invites-js.js
@@ -114,6 +114,14 @@ jQuery(document).ready( function() {
 			});
 		}
 	);
+
+	j("#send-invite-form").on( 'focus', '#send-to-input', function() {
+		j( '#submit' ).prop('disabled', true);
+	});
+
+	j("#send-invite-form").on( 'blur', '#send-to-input', function() {
+		ia_refresh_submit_button_state();
+	});
 });
 
 function ia_on_autocomplete_select( value, data ) {


### PR DESCRIPTION
Prevents form submission (using return key, mostly) if no invites are listed.

This is sort of a follow-up to the ajax spinner you just added, and sort of addresses similar problems. Some of my users are typing in a search string and hitting "enter" before the autocomplete response. Of course, nothing happens. 

I thought it would make sense to disable the "submit" button if no invites are in the list. I also disabled the submit button while the user is interacting with the autocomplete search box to prevent reflexive "enter" key behavior from becoming accidental submits.

Let me know what you think.
