### PR TITLE
Fix deprecated PHP 4 style constructor on widget.php

### DIFF
--- a/widgets/widgets.php
+++ b/widgets/widgets.php
@@ -24,7 +24,7 @@ class InviteAnyoneWidget extends WP_Widget {
 		$control_ops = array( 'width' => 300, 'height' => 350, 'id_base' => 'invite-anyone-widget' );
 
 		/* Create the widget. */
-		$this->WP_Widget( 'invite-anyone-widget', 'Invite Anyone', $widget_ops, $control_ops );
+		parent::__construct( 'invite-anyone-widget', 'Invite Anyone', $widget_ops, $control_ops );
 
 		if ( is_active_widget( false, false, $this->id_base ) )
 			wp_enqueue_style( 'invite-anyone-widget-style', WP_PLUGIN_URL . '/invite-anyone/widgets/widgets-css.css' );


### PR DESCRIPTION
r32990 introduced a change so that all classes use the PHP5 style constructors, while still retaining the PHP4 style constructors for backwards compatibility. For WordPress classes (not external libraries), a deprecated_constructor warning that follows the same rules as deprecated_function will also be displayed. This is designed to help ease the transition to PHP7.

https://make.wordpress.org/core/2015/07/02/deprecating-php4-style-constructors-in-wordpress-4-3/