### PR TITLE
sort typeahead results by name instead of username

### DIFF
--- a/group-invites/group-invites.php
+++ b/group-invites/group-invites.php
@@ -290,6 +290,7 @@ function invite_anyone_invite_query( $group_id = false, $search_terms = false, $
 		'exclude' => $group_members,
 		'search' => $search_terms,
 		'fields' => $fields,
+		'orderby' => 'display_name',
 	) );
 
 	return $user_query->results;


### PR DESCRIPTION
We've found this to be a bit more intuitive—for our user base, anyway.