### PR TITLE
Only clear cookie when it has been set.

### DIFF
--- a/by-email/by-email.php
+++ b/by-email/by-email.php
@@ -427,26 +427,31 @@ add_action( 'wp', 'invite_anyone_catch_send' );
 function invite_anyone_catch_clear() {
 	global $bp;
 
-	$returned_data = isset( $_COOKIE['invite-anyone'] ) ? unserialize( stripslashes( $_COOKIE['invite-anyone'] ) ) : '';
-	if ( $returned_data ) {
-		// We'll take a moment nice and early in the loading process to get returned_data
-		$keys = array(
-			'error_message',
-			'error_emails',
-			'subject',
-			'message',
-			'groups',
-		);
+	if ( isset( $_COOKIE['invite-anyone'] ) ) {
+		$returned_data = unserialize( stripslashes( $_COOKIE['invite-anyone'] ) );
 
-		foreach ( $keys as $key ) {
-			$bp->invite_anyone->returned_data[ $key ] = null;
-			if ( isset( $returned_data[ $key ] ) ) {
-				$value = stripslashes_deep( $returned_data[ $key ] );
-				$bp->invite_anyone->returned_data[ $key ] = $value;
+		if ( $returned_data ) {
+			// We'll take a moment nice and early in the loading process to get returned_data
+			$keys = array(
+				'error_message',
+				'error_emails',
+				'subject',
+				'message',
+				'groups',
+			);
+
+			foreach ( $keys as $key ) {
+				$bp->invite_anyone->returned_data[ $key ] = null;
+				if ( isset( $returned_data[ $key ] ) ) {
+					$value = stripslashes_deep( $returned_data[ $key ] );
+					$bp->invite_anyone->returned_data[ $key ] = $value;
+				}
 			}
 		}
+
+		setcookie( 'invite-anyone', null, -1, '/' );
+
 	}
-	@setcookie( 'invite-anyone', '', time() - 3600, '/' );
 
 	if ( isset( $_GET['clear'] ) ) {
 		$clear_id = $_GET['clear'];


### PR DESCRIPTION
Always clearing a (potentially nonexistent) cookie prevents Batcache from batcaching.