### PR TITLE
Updating CloudSponge to use the Universal Snippet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_store
 .svn
 *.swp
+autocomplete

--- a/admin/admin-panel.php
+++ b/admin/admin-panel.php
@@ -443,7 +443,18 @@ function invite_anyone_settings_cs_content() {
 			<?php
 				} else {
 			?>
-					<label for="invite_anyone[cloudsponge_key]"><?php _e( 'CloudSponge Account Key', 'invite-anyone' ) ?></label> <input type="text" id="cloudsponge-key" name="invite_anyone[cloudsponge_account_key]" value="<?php echo esc_html( $account_key ) ?>" /> <span class="description"><?php _e( 'CloudSponge integration will not work without a valid CloudSponge Account key.', 'invite-anyone' ) ?></span>
+					<label for="invite_anyone[cloudsponge_key]"><?php _e( 'CloudSponge Account Key', 'invite-anyone' ) ?></label>
+					<input type="text" id="cloudsponge-key" name="invite_anyone[cloudsponge_account_key]" value="<?php echo esc_html( $account_key ) ?>" />
+					<?php if ( $account_key ) { ?>
+						<script type="text/javascript">
+							(function(u){
+							  var d=document,s='script',a=d.createElement(s),m=d.getElementsByTagName(s)[0];
+							  a.async=1;a.src=u;m.parentNode.insertBefore(a,m);
+							})('//api.cloudsponge.com/widget/<?php _e($account_key) ?>.js');
+						</script>
+						<button id="test-cloudsponge-button" name="test-cloudsponge-button" type="button" onclick="csLaunch();"><?php _e('Test'); ?></button>
+					<?php } ?>
+					<span class="description"><?php _e( 'CloudSponge integration will not work without a valid CloudSponge Account key.', 'invite-anyone' ) ?></span>
 			<?php
 				}
 			?>

--- a/admin/admin-panel.php
+++ b/admin/admin-panel.php
@@ -418,12 +418,13 @@ function invite_anyone_settings_cs_content() {
 	}
 	// Trying to give to CloudSponge user email and name to pre populate signup
 	// form and reduce friction
-	$cloudsponge_params = '?utm_source=invite-anyone&utm_medium=partner&utm_campaign=integrator&email='.urlencode(wp_get_current_user()->user_email);
+	$cloudsponge_params = '?utm_source=invite-anyone&utm_medium=partner&utm_campaign=integrator';
+	$cloudsponge_additional_params = '&email='.urlencode(wp_get_current_user()->user_email);
 	if($cloudsponge_name){
-		$cloudsponge_params.= '&name='.urlencode($cloudsponge_name);
+		$cloudsponge_additional_params.= '&name='.urlencode($cloudsponge_name);
 	}
 	$cloudsponge_link = 'http://www.cloudsponge.com'.$cloudsponge_params;
-	$cloudsponge_signup_link = 'https://app.cloudsponge.com/users/sign_up'.$cloudsponge_params;
+	$cloudsponge_signup_link = 'https://app.cloudsponge.com/users/sign_up'.$cloudsponge_params.$cloudsponge_additional_params;
 
 ?>
 	<div class="cs">

--- a/admin/admin-panel.php
+++ b/admin/admin-panel.php
@@ -455,7 +455,7 @@ function invite_anyone_settings_cs_content() {
 
 						?>
 
-						<button id="test-cloudsponge-button" name="test-cloudsponge-button" type="button" onclick="csLaunch();"><?php _e('Test'); ?></button>
+						<button id="test-cloudsponge-button" name="test-cloudsponge-button" type="button" onclick="csLaunch();"><?php _e( 'Test', 'invite-anyone' ); ?></button>
 					<?php } ?>
 					<span class="description"><?php _e( 'CloudSponge integration will not work without a valid CloudSponge Key.', 'invite-anyone' ) ?></span>
 			<?php

--- a/admin/admin-panel.php
+++ b/admin/admin-panel.php
@@ -451,7 +451,7 @@ function invite_anyone_settings_cs_content() {
 			<?php
 				} else {
 			?>
-					<label for="invite_anyone[cloudsponge_key]"><?php _e( 'CloudSponge Account Key', 'invite-anyone' ) ?></label>
+					<label for="invite_anyone[cloudsponge_key]"><?php _e( 'CloudSponge Key', 'invite-anyone' ) ?></label>
 					<input type="text" id="cloudsponge-key" name="invite_anyone[cloudsponge_account_key]" value="<?php echo esc_html( $account_key ) ?>" />
 					<?php if ( $account_key ) {
 
@@ -460,7 +460,7 @@ function invite_anyone_settings_cs_content() {
 
 						<button id="test-cloudsponge-button" name="test-cloudsponge-button" type="button" onclick="csLaunch();"><?php _e('Test'); ?></button>
 					<?php } ?>
-					<span class="description"><?php _e( 'CloudSponge integration will not work without a valid CloudSponge Account key.', 'invite-anyone' ) ?></span>
+					<span class="description"><?php _e( 'CloudSponge integration will not work without a valid CloudSponge Key.', 'invite-anyone' ) ?></span>
 			<?php
 				}
 			?>

--- a/admin/admin-panel.php
+++ b/admin/admin-panel.php
@@ -424,6 +424,14 @@ function invite_anyone_settings_cs_content() {
 	// Landing on Signup Form
 	$cloudsponge_signup_link = 'https://app.cloudsponge.com/users/sign_up'.$cloudsponge_params.$cloudsponge_additional_params;
 
+	// Include CloudSponge Universal Snippet, so user can launch it clicking
+	// on `Test` button
+	wp_register_script( 'ia_cloudsponge', WP_PLUGIN_URL . '/invite-anyone/by-email/cloudsponge-js.js', array(), false, true );
+	$strings['account_key'] = $account_key;
+	$strings['domain_key'] = false;
+	wp_localize_script( 'ia_cloudsponge', 'ia_cloudsponge', $strings );
+	wp_enqueue_script( 'ia_cloudsponge' );
+
 ?>
 	<div class="cs">
 		<a href="<?php _e($cloudsponge_link) ?>"><img class="cs-logo" src="<?php echo plugins_url( 'invite-anyone/images/cloudsponge_logo.png' ) ?>" /></a>
@@ -445,13 +453,11 @@ function invite_anyone_settings_cs_content() {
 			?>
 					<label for="invite_anyone[cloudsponge_key]"><?php _e( 'CloudSponge Account Key', 'invite-anyone' ) ?></label>
 					<input type="text" id="cloudsponge-key" name="invite_anyone[cloudsponge_account_key]" value="<?php echo esc_html( $account_key ) ?>" />
-					<?php if ( $account_key ) { ?>
-						<script type="text/javascript">
-							(function(u){
-							  var d=document,s='script',a=d.createElement(s),m=d.getElementsByTagName(s)[0];
-							  a.async=1;a.src=u;m.parentNode.insertBefore(a,m);
-							})('//api.cloudsponge.com/widget/<?php _e($account_key) ?>.js');
-						</script>
+					<?php if ( $account_key ) {
+
+
+						?>
+
 						<button id="test-cloudsponge-button" name="test-cloudsponge-button" type="button" onclick="csLaunch();"><?php _e('Test'); ?></button>
 					<?php } ?>
 					<span class="description"><?php _e( 'CloudSponge integration will not work without a valid CloudSponge Account key.', 'invite-anyone' ) ?></span>

--- a/admin/admin-panel.php
+++ b/admin/admin-panel.php
@@ -408,13 +408,27 @@ function invite_anyone_settings_cs_content() {
 	$options = invite_anyone_options();
 	$domain_key = !empty( $options['cloudsponge_key'] ) ? $options['cloudsponge_key'] : '';
 	$account_key = !empty( $options['cloudsponge_account_key'] ) ? $options['cloudsponge_account_key'] : '';
+	// Capturing current user name
+	$cloudsponge_name = '';
+	if(wp_get_current_user()->first_name){
+		$cloudsponge_name = wp_get_current_user()->first_name;
+		if(wp_get_current_user()->last_name){
+			$cloudsponge_name.= ' '.wp_get_current_user()->last_name;
+		}
+	}
+	// Trying to give to CloudSponge user email and name to pre populate signup
+	// form and reduce friction
+	$cloudsponge_link = 'http://www.cloudsponge.com/?utm_source=invite-anyone&utm_medium=partner&utm_campaign=integrator&email='.urlencode(wp_get_current_user()->user_email);
+	if($cloudsponge_name){
+		$cloudsponge_link.= '&name='.urlencode($cloudsponge_name);
+	}
 
 ?>
 	<div class="cs">
-		<a href="http://www.cloudsponge.com/?utm_source=invite-anyone&utm_medium=partner&utm_campaign=integrator"><img class="cs-logo" src="<?php echo plugins_url( 'invite-anyone/images/cloudsponge_logo.png' ) ?>" /></a>
+		<a href="<?php _e($cloudsponge_link) ?>"><img class="cs-logo" src="<?php echo plugins_url( 'invite-anyone/images/cloudsponge_logo.png' ) ?>" /></a>
 
 		<div class="cs-explain">
-			<p><?php _e( '<a href="http://www.cloudsponge.com/?utm_source=invite-anyone&utm_medium=partner&utm_campaign=integrator">CloudSponge</a> is a cool service that gives your users easy and secure access to their address books (Facebook, LinkedIn, Gmail, Yahoo, and a number of other online and desktop email clients), so that they can more easily invite friends to your site. It#8217;s a great way to increase engagement on your site, by making it easier for them to invite new members. In order to enable CloudSponge support in Invite Anyone and BuddyPress, you\'ll need to <a href="http://www.cloudsponge.com/signup?utm_source=invite-anyone&utm_medium=partner&utm_campaign=integrator">register for a CloudSponge account</a>.', 'invite-anyone' ) ?></p>
+			<p><?php _e( '<a href="'.$cloudsponge_link.'">CloudSponge</a> is a cool service that gives your users easy and secure access to their address books (Facebook, LinkedIn, Gmail, Yahoo, and a number of other online and desktop email clients), so that they can more easily invite friends to your site. It#8217;s a great way to increase engagement on your site, by making it easier for them to invite new members. In order to enable CloudSponge support in Invite Anyone and BuddyPress, you\'ll need to <a href="'.$cloudsponge_link.'">register for a CloudSponge account</a>.', 'invite-anyone' ) ?></p>
 
 			<label for="invite_anyone[cloudsponge_enabled]"><input type="checkbox" name="invite_anyone[cloudsponge_enabled]" id="cloudsponge-enabled" <?php checked( $options['cloudsponge_enabled'], 'on' ) ?>/> <strong><?php _e( 'Enable CloudSponge?', 'invite-anyone' ) ?></strong></label>
 		</div>

--- a/admin/admin-panel.php
+++ b/admin/admin-panel.php
@@ -408,22 +408,20 @@ function invite_anyone_settings_cs_content() {
 	$options = invite_anyone_options();
 	$domain_key = !empty( $options['cloudsponge_key'] ) ? $options['cloudsponge_key'] : '';
 	$account_key = !empty( $options['cloudsponge_account_key'] ) ? $options['cloudsponge_account_key'] : '';
-	// Capturing current user name
-	$cloudsponge_name = '';
+	// Trying to give to CloudSponge user email and name to pre populate signup
+	// form and reduce friction
+	$cloudsponge_params = '?utm_source=invite-anyone&utm_medium=partner&utm_campaign=integrator';
+	$cloudsponge_additional_params = '&email='.urlencode(wp_get_current_user()->user_email);
 	if(wp_get_current_user()->first_name){
 		$cloudsponge_name = wp_get_current_user()->first_name;
 		if(wp_get_current_user()->last_name){
 			$cloudsponge_name.= ' '.wp_get_current_user()->last_name;
 		}
-	}
-	// Trying to give to CloudSponge user email and name to pre populate signup
-	// form and reduce friction
-	$cloudsponge_params = '?utm_source=invite-anyone&utm_medium=partner&utm_campaign=integrator';
-	$cloudsponge_additional_params = '&email='.urlencode(wp_get_current_user()->user_email);
-	if($cloudsponge_name){
 		$cloudsponge_additional_params.= '&name='.urlencode($cloudsponge_name);
 	}
+	// Landing to home
 	$cloudsponge_link = 'http://www.cloudsponge.com'.$cloudsponge_params;
+	// Landing on Signup Form
 	$cloudsponge_signup_link = 'https://app.cloudsponge.com/users/sign_up'.$cloudsponge_params.$cloudsponge_additional_params;
 
 ?>

--- a/admin/admin-panel.php
+++ b/admin/admin-panel.php
@@ -424,7 +424,7 @@ function invite_anyone_settings_cs_content() {
 	// Landing on Signup Form
 	$cloudsponge_signup_link = 'https://app.cloudsponge.com/users/sign_up'.$cloudsponge_params.$cloudsponge_additional_params;
 
-	// Include CloudSponge Universal Snippet, so user can launch it clicking
+	// Include CloudSponge Snippet, so user can launch it clicking
 	// on `Test` button
 	wp_register_script( 'ia_cloudsponge', WP_PLUGIN_URL . '/invite-anyone/by-email/cloudsponge-js.js', array(), false, true );
 	$strings['account_key'] = $account_key;

--- a/admin/admin-panel.php
+++ b/admin/admin-panel.php
@@ -418,17 +418,19 @@ function invite_anyone_settings_cs_content() {
 	}
 	// Trying to give to CloudSponge user email and name to pre populate signup
 	// form and reduce friction
-	$cloudsponge_link = 'http://www.cloudsponge.com/?utm_source=invite-anyone&utm_medium=partner&utm_campaign=integrator&email='.urlencode(wp_get_current_user()->user_email);
+	$cloudsponge_params = '?utm_source=invite-anyone&utm_medium=partner&utm_campaign=integrator&email='.urlencode(wp_get_current_user()->user_email);
 	if($cloudsponge_name){
-		$cloudsponge_link.= '&name='.urlencode($cloudsponge_name);
+		$cloudsponge_params.= '&name='.urlencode($cloudsponge_name);
 	}
+	$cloudsponge_link = 'http://www.cloudsponge.com'.$cloudsponge_params;
+	$cloudsponge_signup_link = 'https://app.cloudsponge.com/users/sign_up'.$cloudsponge_params;
 
 ?>
 	<div class="cs">
 		<a href="<?php _e($cloudsponge_link) ?>"><img class="cs-logo" src="<?php echo plugins_url( 'invite-anyone/images/cloudsponge_logo.png' ) ?>" /></a>
 
 		<div class="cs-explain">
-			<p><?php _e( '<a href="'.$cloudsponge_link.'">CloudSponge</a> is a cool service that gives your users easy and secure access to their address books (Facebook, LinkedIn, Gmail, Yahoo, and a number of other online and desktop email clients), so that they can more easily invite friends to your site. It#8217;s a great way to increase engagement on your site, by making it easier for them to invite new members. In order to enable CloudSponge support in Invite Anyone and BuddyPress, you\'ll need to <a href="'.$cloudsponge_link.'">register for a CloudSponge account</a>.', 'invite-anyone' ) ?></p>
+			<p><?php _e( '<a href="'.$cloudsponge_link.'">CloudSponge</a> is a cool service that gives your users easy and secure access to their address books (Facebook, LinkedIn, Gmail, Yahoo, and a number of other online and desktop email clients), so that they can more easily invite friends to your site. It#8217;s a great way to increase engagement on your site, by making it easier for them to invite new members. In order to enable CloudSponge support in Invite Anyone and BuddyPress, you\'ll need to <a href="'.$cloudsponge_signup_link.'">register for a CloudSponge account</a>.', 'invite-anyone' ) ?></p>
 
 			<label for="invite_anyone[cloudsponge_enabled]"><input type="checkbox" name="invite_anyone[cloudsponge_enabled]" id="cloudsponge-enabled" <?php checked( $options['cloudsponge_enabled'], 'on' ) ?>/> <strong><?php _e( 'Enable CloudSponge?', 'invite-anyone' ) ?></strong></label>
 		</div>

--- a/admin/admin-panel.php
+++ b/admin/admin-panel.php
@@ -405,7 +405,7 @@ function invite_anyone_settings_group_invite_visibility() {
 function invite_anyone_settings_cs_content() {
 
 	$options 	= invite_anyone_options();
-	$domain_key 	= !empty( $options['cloudsponge_key'] ) ? $options['cloudsponge_key'] : '';
+	$account_key 	= !empty( $options['cloudsponge_key'] ) ? $options['cloudsponge_key'] : '';
 
 ?>
 	<div class="cs">
@@ -418,7 +418,7 @@ function invite_anyone_settings_cs_content() {
 		</div>
 
 		<div class="cs-settings">
-			<label for="invite_anyone[cloudsponge_key]"><?php _e( 'CloudSponge Domain Key', 'invite-anyone' ) ?></label> <input type="text" id="cloudsponge-key" name="invite_anyone[cloudsponge_key]" value="<?php echo esc_html( $domain_key ) ?>" /> <span class="description"><?php _e( 'CloudSponge integration will not work without a valid domain key.', 'invite-anyone' ) ?></span>
+			<label for="invite_anyone[cloudsponge_key]"><?php _e( 'CloudSponge Account Key', 'invite-anyone' ) ?></label> <input type="text" id="cloudsponge-key" name="invite_anyone[cloudsponge_key]" value="<?php echo esc_html( $account_key ) ?>" /> <span class="description"><?php _e( 'CloudSponge integration will not work without a valid CloudSponge Account key.', 'invite-anyone' ) ?></span>
 
 			<p class="description"><?php _e( 'When you use CloudSponge with Invite Anyone, part of your CloudSponge monthly payment goes to the author of Invite Anyone. This is a great way to support future development of the plugin. Thanks for your support!', 'invite-anyone' ) ?></p>
 		</div>

--- a/admin/admin-panel.php
+++ b/admin/admin-panel.php
@@ -434,10 +434,10 @@ function invite_anyone_settings_cs_content() {
 
 ?>
 	<div class="cs">
-		<a href="<?php _e($cloudsponge_link) ?>"><img class="cs-logo" src="<?php echo plugins_url( 'invite-anyone/images/cloudsponge_logo.png' ) ?>" /></a>
+		<img class="cs-logo" src="<?php echo plugins_url( 'invite-anyone/images/cloudsponge_logo.png' ) ?>" />
 
 		<div class="cs-explain">
-			<p><?php _e( '<a href="'.$cloudsponge_link.'">CloudSponge</a> is a cool service that gives your users easy and secure access to their address books (Facebook, LinkedIn, Gmail, Yahoo, and a number of other online and desktop email clients), so that they can more easily invite friends to your site. It#8217;s a great way to increase engagement on your site, by making it easier for them to invite new members. In order to enable CloudSponge support in Invite Anyone and BuddyPress, you\'ll need to <a href="'.$cloudsponge_signup_link.'">register for a CloudSponge account</a>.', 'invite-anyone' ) ?></p>
+			<p><?php _e( 'CloudSponge is a cool service that gives your users easy and secure access to their address books (LinkedIn, Gmail, Yahoo, and a number of other online and desktop email clients), so that they can more easily invite friends to your site. It\'s a great way to increase engagement on your site, by making it easier for them to invite new members. In order to enable CloudSponge support in Invite Anyone and BuddyPress, you\'ll need to <a href="'.$cloudsponge_signup_link.'">register for a CloudSponge account</a>.', 'invite-anyone' ) ?></p>
 
 			<label for="invite_anyone[cloudsponge_enabled]"><input type="checkbox" name="invite_anyone[cloudsponge_enabled]" id="cloudsponge-enabled" <?php checked( $options['cloudsponge_enabled'], 'on' ) ?>/> <strong><?php _e( 'Enable CloudSponge?', 'invite-anyone' ) ?></strong></label>
 		</div>

--- a/admin/admin-panel.php
+++ b/admin/admin-panel.php
@@ -412,12 +412,9 @@ function invite_anyone_settings_cs_content() {
 	// form and reduce friction
 	$cloudsponge_params = '?utm_source=invite-anyone&utm_medium=partner&utm_campaign=integrator';
 	$cloudsponge_additional_params = '&email='.urlencode(wp_get_current_user()->user_email);
-	if(wp_get_current_user()->first_name){
-		$cloudsponge_name = wp_get_current_user()->first_name;
-		if(wp_get_current_user()->last_name){
-			$cloudsponge_name.= ' '.wp_get_current_user()->last_name;
-		}
-		$cloudsponge_additional_params.= '&name='.urlencode($cloudsponge_name);
+	$display_name = bp_core_get_user_displayname( bp_loggedin_user_id() );
+	if($display_name){
+		$cloudsponge_additional_params.= '&name='.urlencode($display_name);
 	}
 	// Landing to home
 	$cloudsponge_link = 'http://www.cloudsponge.com'.$cloudsponge_params;

--- a/admin/admin-panel.php
+++ b/admin/admin-panel.php
@@ -82,7 +82,8 @@ function invite_anyone_admin_panel() {
 			),
 			'cloudsponge' => array(
 				'cloudsponge_enabled',
-				'cloudsponge_key'
+				'cloudsponge_key',
+				'cloudsponge_account_key',
 			),
 			'general-settings' => array(
 				'can_send_group_invites_email',
@@ -404,8 +405,9 @@ function invite_anyone_settings_group_invite_visibility() {
 
 function invite_anyone_settings_cs_content() {
 
-	$options 	= invite_anyone_options();
-	$account_key 	= !empty( $options['cloudsponge_key'] ) ? $options['cloudsponge_key'] : '';
+	$options = invite_anyone_options();
+	$domain_key = !empty( $options['cloudsponge_key'] ) ? $options['cloudsponge_key'] : '';
+	$account_key = !empty( $options['cloudsponge_account_key'] ) ? $options['cloudsponge_account_key'] : '';
 
 ?>
 	<div class="cs">
@@ -418,7 +420,18 @@ function invite_anyone_settings_cs_content() {
 		</div>
 
 		<div class="cs-settings">
-			<label for="invite_anyone[cloudsponge_key]"><?php _e( 'CloudSponge Account Key', 'invite-anyone' ) ?></label> <input type="text" id="cloudsponge-key" name="invite_anyone[cloudsponge_key]" value="<?php echo esc_html( $account_key ) ?>" /> <span class="description"><?php _e( 'CloudSponge integration will not work without a valid CloudSponge Account key.', 'invite-anyone' ) ?></span>
+
+			<?php
+				if ( $domain_key ) {
+			?>
+					<label for="invite_anyone[cloudsponge_key]"><?php _e( 'CloudSponge Domain Key', 'invite-anyone' ) ?></label> <input type="text" id="cloudsponge-key" name="invite_anyone[cloudsponge_key]" value="<?php echo esc_html( $domain_key ) ?>" /> <span class="description"><?php _e( 'CloudSponge integration will not work without a valid CloudSponge Domain key.', 'invite-anyone' ) ?></span>
+			<?php
+				} else {
+			?>
+					<label for="invite_anyone[cloudsponge_key]"><?php _e( 'CloudSponge Account Key', 'invite-anyone' ) ?></label> <input type="text" id="cloudsponge-key" name="invite_anyone[cloudsponge_account_key]" value="<?php echo esc_html( $account_key ) ?>" /> <span class="description"><?php _e( 'CloudSponge integration will not work without a valid CloudSponge Account key.', 'invite-anyone' ) ?></span>
+			<?php
+				}
+			?>
 
 			<p class="description"><?php _e( 'When you use CloudSponge with Invite Anyone, part of your CloudSponge monthly payment goes to the author of Invite Anyone. This is a great way to support future development of the plugin. Thanks for your support!', 'invite-anyone' ) ?></p>
 		</div>

--- a/by-email/cloudsponge-integration.php
+++ b/by-email/cloudsponge-integration.php
@@ -16,9 +16,10 @@ class Cloudsponge_Integration {
 			$options = get_option( 'invite_anyone' );
 
 		$this->enabled = !empty( $options['cloudsponge_enabled'] ) ? $options['cloudsponge_enabled'] : false;
-		$this->key     = !empty( $options['cloudsponge_key'] ) ? $options['cloudsponge_key'] : false;
+		$this->domain_key = !empty( $options['cloudsponge_key'] ) ? $options['cloudsponge_key'] : false;
+		$this->account_key = !empty( $options['cloudsponge_domain_key'] ) ? $options['cloudsponge_domain_key'] : false;
 
-		if ( $this->enabled && $this->key ) {
+		if ( $this->enabled && ( $this->domain_key || $this->account_key ) ) {
 			define( 'INVITE_ANYONE_CS_ENABLED', true );
 			add_action( 'invite_anyone_after_addresses', array( $this, 'import_markup' ) );
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_script' ) );
@@ -32,11 +33,20 @@ class Cloudsponge_Integration {
 	 * @since 0.8.8
 	 */
 	function enqueue_script() {
-		wp_register_script( 'ia_cloudsponge', WP_PLUGIN_URL . '/invite-anyone/by-email/cloudsponge-js.js', array(), false, true );
 
-		// The domain key must be printed as a javascript object so it's accessible to the
-		// script
-		$strings = array( 'account_key' => $this->key );
+		// Values available in the JavaScript side
+		$strings = array();
+
+		if ($this->domain_key) {
+			wp_register_script( 'ia_cloudsponge_address_books', 'https://api.cloudsponge.com/address_books.js', array(), false, true );
+			wp_register_script( 'ia_cloudsponge', WP_PLUGIN_URL . '/invite-anyone/by-email/cloudsponge-js.js', array( 'ia_cloudsponge_address_books' ), false, true );
+			$strings = ['domain_key'] = $this->domain_key;
+			$strings = ['account_key'] = false;
+		} else {
+			wp_register_script( 'ia_cloudsponge', WP_PLUGIN_URL . '/invite-anyone/by-email/cloudsponge-js.js', array(), false, true );
+			$strings['account_key'] = $this->account_key;
+			$strings['domain_key'] = false;
+		}
 
 		if ( $locale = apply_filters( 'ia_cloudsponge_locale', '' ) ) {
 			$strings['locale'] = $locale;

--- a/by-email/cloudsponge-integration.php
+++ b/by-email/cloudsponge-integration.php
@@ -40,8 +40,8 @@ class Cloudsponge_Integration {
 		if ($this->domain_key) {
 			wp_register_script( 'ia_cloudsponge_address_books', 'https://api.cloudsponge.com/address_books.js', array(), false, true );
 			wp_register_script( 'ia_cloudsponge', WP_PLUGIN_URL . '/invite-anyone/by-email/cloudsponge-js.js', array( 'ia_cloudsponge_address_books' ), false, true );
-			$strings = ['domain_key'] = $this->domain_key;
-			$strings = ['account_key'] = false;
+			$strings['domain_key'] = $this->domain_key;
+			$strings['account_key'] = false;
 		} else {
 			wp_register_script( 'ia_cloudsponge', WP_PLUGIN_URL . '/invite-anyone/by-email/cloudsponge-js.js', array(), false, true );
 			$strings['account_key'] = $this->account_key;

--- a/by-email/cloudsponge-integration.php
+++ b/by-email/cloudsponge-integration.php
@@ -32,12 +32,11 @@ class Cloudsponge_Integration {
 	 * @since 0.8.8
 	 */
 	function enqueue_script() {
-		wp_register_script( 'ia_cloudsponge_address_books', 'https://api.cloudsponge.com/address_books.js', array(), false, true );
-		wp_register_script( 'ia_cloudsponge', WP_PLUGIN_URL . '/invite-anyone/by-email/cloudsponge-js.js', array( 'ia_cloudsponge_address_books' ), false, true );
+		wp_register_script( 'ia_cloudsponge', WP_PLUGIN_URL . '/invite-anyone/by-email/cloudsponge-js.js', array(), false, true );
 
 		// The domain key must be printed as a javascript object so it's accessible to the
 		// script
-		$strings = array( 'domain_key' => $this->key );
+		$strings = array( 'account_key' => $this->key );
 
 		if ( $locale = apply_filters( 'ia_cloudsponge_locale', '' ) ) {
 			$strings['locale'] = $locale;

--- a/by-email/cloudsponge-js.js
+++ b/by-email/cloudsponge-js.js
@@ -1,5 +1,9 @@
+(function(u){
+  var d=document,s='script',a=d.createElement(s),m=d.getElementsByTagName(s)[0];
+  a.async=1;a.src=u;m.parentNode.insertBefore(a,m);
+})('//api.cloudsponge.com/widget/'+ia_cloudsponge.account_key+'.js');
+
 var csPageOptions = {
-	domain_key: ia_cloudsponge.domain_key,
 	referrer: 'invite-anyone',
 	sources: [ 'linkedin', 'yahoo', 'gmail', 'windowslive', 'aol', 'plaxo', 'addressbook', 'outlook' ],
 	afterSubmitContacts:function(contacts) {
@@ -12,11 +16,10 @@ var csPageOptions = {
 			emails.push(email);
 		}
 
-
 		var textarea = document.getElementById('invite-anyone-email-addresses');
 		/* Strip any manually entered whitespace */
 		var already_emails = textarea.value.replace(/^\s+|\s+$/g,"");
-		
+
 		var new_emails;
 		var new_emails_for_input;
 		if ( already_emails == false ) {

--- a/by-email/cloudsponge-js.js
+++ b/by-email/cloudsponge-js.js
@@ -1,7 +1,10 @@
-(function(u){
-  var d=document,s='script',a=d.createElement(s),m=d.getElementsByTagName(s)[0];
-  a.async=1;a.src=u;m.parentNode.insertBefore(a,m);
-})('//api.cloudsponge.com/widget/'+ia_cloudsponge.account_key+'.js');
+
+if ( ia_cloudsponge.account_key ) {
+	(function(u){
+	  var d=document,s='script',a=d.createElement(s),m=d.getElementsByTagName(s)[0];
+	  a.async=1;a.src=u;m.parentNode.insertBefore(a,m);
+	})('//api.cloudsponge.com/widget/'+ia_cloudsponge.account_key+'.js');
+}
 
 var csPageOptions = {
 	referrer: 'invite-anyone',
@@ -33,6 +36,11 @@ var csPageOptions = {
 		document.getElementById('cloudsponge-emails').value = new_emails_for_input;
 	}
 }
+
+if ( ia_cloudsponge.domain_key ) {
+	csPageOptions.domain_key = ia_cloudsponge.domain_key;
+}
+
 
 if ( ia_cloudsponge.locale ) {
 	cloudsponge.init( { locale: 'es' } );


### PR DESCRIPTION
This change will allow the user to enter the CloudSponge Account key found in the Universal Snippet and avoid users to ask for CloudSponge domain keys.

The Account key will work with any domain.

This is a sample of the Universal Snippet that user receives after create a new CloudSponge account:

```javascript
(function(u){
  var d=document,s='script',a=d.createElement(s),m=d.getElementsByTagName(s)[0];
  a.async=1;a.src=u;m.parentNode.insertBefore(a,m);
})('//api.cloudsponge.com/widget/ACCOUNT_KEY.js');
```

These changes will allow the user to copy the `ACCOUNT_KEY` (which is a hash type value) and enter in the InviteAnyone admin settings, instead of enter the CloudSponge Domain Key (which relies in contact CloudSponge support).