### PR TITLE
Replace WP_PLUGIN_URL by plugins_url().

### DIFF
--- a/admin/admin-panel.php
+++ b/admin/admin-panel.php
@@ -30,11 +30,11 @@ add_filter( 'plugin_action_links', 'invite_anyone_admin_add_action_link', 10, 2 
 
 
 function invite_anyone_admin_scripts() {
-	wp_enqueue_script( 'invite-anyone-admin-js', WP_PLUGIN_URL . '/invite-anyone/admin/admin-js.js' );
+	wp_enqueue_script( 'invite-anyone-admin-js', plugins_url() . '/invite-anyone/admin/admin-js.js' );
 }
 
 function invite_anyone_admin_styles() {
-	wp_enqueue_style( 'invite-anyone-admin-css', WP_PLUGIN_URL . '/invite-anyone/admin/admin-css.css' );
+	wp_enqueue_style( 'invite-anyone-admin-css', plugins_url() . '/invite-anyone/admin/admin-css.css' );
 }
 
 function invite_anyone_admin_panel() {
@@ -426,7 +426,7 @@ function invite_anyone_settings_cs_content() {
 
 	// Include CloudSponge Snippet, so user can launch it clicking
 	// on `Test` button
-	wp_register_script( 'ia_cloudsponge', WP_PLUGIN_URL . '/invite-anyone/by-email/cloudsponge-js.js', array(), false, true );
+	wp_register_script( 'ia_cloudsponge', plugins_url() . '/invite-anyone/by-email/cloudsponge-js.js', array(), false, true );
 	$strings['account_key'] = $account_key;
 	$strings['domain_key'] = false;
 	wp_localize_script( 'ia_cloudsponge', 'ia_cloudsponge', $strings );

--- a/by-email/by-email-db.php
+++ b/by-email/by-email-db.php
@@ -100,7 +100,7 @@ class Invite_Anyone_Schema {
 			'_builtin' 	=> false,
 			'show_ui' 	=> $this->show_dashboard_ui(),
 			'hierarchical' 	=> false,
-			'menu_icon'	=> WP_PLUGIN_URL . '/invite-anyone/images/smallest_buddypress_icon_ev.png',
+			'menu_icon'	=> plugins_url() . '/invite-anyone/images/smallest_buddypress_icon_ev.png',
 			'supports' 	=> array( 'title', 'editor', 'custom-fields', 'author' )
 		), $this ) );
 

--- a/by-email/by-email.php
+++ b/by-email/by-email.php
@@ -21,7 +21,7 @@ function invite_anyone_add_by_email_css() {
 	global $bp;
 
 	if ( $bp->current_component == BP_INVITE_ANYONE_SLUG ) {
-   		$style_url = WP_PLUGIN_URL . '/invite-anyone/by-email/by-email-css.css';
+   		$style_url = plugins_url() . '/invite-anyone/by-email/by-email-css.css';
         $style_file = WP_PLUGIN_DIR . '/invite-anyone/by-email/by-email-css.css';
         if (file_exists($style_file)) {
             wp_register_style('invite-anyone-by-email-style', $style_url);
@@ -35,7 +35,7 @@ function invite_anyone_add_by_email_js() {
 	global $bp;
 
 	if ( $bp->current_component == BP_INVITE_ANYONE_SLUG ) {
-   		$style_url = WP_PLUGIN_URL . '/invite-anyone/by-email/by-email-js.js';
+   		$style_url = plugins_url() . '/invite-anyone/by-email/by-email-js.js';
         $style_file = WP_PLUGIN_DIR . '/invite-anyone/by-email/by-email-js.js';
         if (file_exists($style_file)) {
             wp_register_script('invite-anyone-by-email-scripts', $style_url);

--- a/by-email/cloudsponge-integration.php
+++ b/by-email/cloudsponge-integration.php
@@ -39,11 +39,11 @@ class Cloudsponge_Integration {
 
 		if ($this->domain_key) {
 			wp_register_script( 'ia_cloudsponge_address_books', 'https://api.cloudsponge.com/address_books.js', array(), false, true );
-			wp_register_script( 'ia_cloudsponge', WP_PLUGIN_URL . '/invite-anyone/by-email/cloudsponge-js.js', array( 'ia_cloudsponge_address_books' ), false, true );
+			wp_register_script( 'ia_cloudsponge', plugins_url() . '/invite-anyone/by-email/cloudsponge-js.js', array( 'ia_cloudsponge_address_books' ), false, true );
 			$strings['domain_key'] = $this->domain_key;
 			$strings['account_key'] = false;
 		} else {
-			wp_register_script( 'ia_cloudsponge', WP_PLUGIN_URL . '/invite-anyone/by-email/cloudsponge-js.js', array(), false, true );
+			wp_register_script( 'ia_cloudsponge', plugins_url() . '/invite-anyone/by-email/cloudsponge-js.js', array(), false, true );
 			$strings['account_key'] = $this->account_key;
 			$strings['domain_key'] = false;
 		}

--- a/widgets/widgets.php
+++ b/widgets/widgets.php
@@ -4,7 +4,7 @@
 function invite_anyone_add_widget_css() {
 	global $bp;
 
-	$style_url = WP_PLUGIN_URL . '/invite-anyone/widgets/widgets-css.css';
+	$style_url = plugins_url() . '/invite-anyone/widgets/widgets-css.css';
 	$style_file = WP_PLUGIN_DIR . '/invite-anyone/widgets/widgets-css.css';
 	if (file_exists($style_file)) {
 		wp_register_style('invite-anyone-widget-style', $style_url);
@@ -27,7 +27,7 @@ class InviteAnyoneWidget extends WP_Widget {
 		parent::__construct( 'invite-anyone-widget', 'Invite Anyone', $widget_ops, $control_ops );
 
 		if ( is_active_widget( false, false, $this->id_base ) )
-			wp_enqueue_style( 'invite-anyone-widget-style', WP_PLUGIN_URL . '/invite-anyone/widgets/widgets-css.css' );
+			wp_enqueue_style( 'invite-anyone-widget-style', plugins_url() . '/invite-anyone/widgets/widgets-css.css' );
 	}
 
 	/**


### PR DESCRIPTION
This fixes a mixed content error when HTTPS is enabled. 

The docs say this kind of constant should not be used by plugins https://codex.wordpress.org/Determining_Plugin_and_Content_Directories#Constants