### PR TITLE
fix search on wordpress prior to 4.0.0

### DIFF
--- a/group-invites/group-invites.php
+++ b/group-invites/group-invites.php
@@ -339,7 +339,9 @@ class Invite_Anyone_User_Query extends WP_User_Query {
 		$searches = array();
 		$leading_wild = ( 'leading' == $wild || 'both' == $wild ) ? '%' : '';
 		$trailing_wild = ( 'trailing' == $wild || 'both' == $wild ) ? '%' : '';
-		$like_string = $leading_wild . $wpdb->esc_like( $string ) . $trailing_wild;
+		$escaped_string = ( method_exists($wpdb, 'esc_like' ) )?
+				$wpdb->esc_like( $string ):addcslashes( $string, '_%\\' );
+		$like_string = $leading_wild . $escaped_string . $trailing_wild;
 		foreach ( $cols as $col ) {
 			$searches[] = $wpdb->prepare( "$col LIKE %s", $like_string );
 		}


### PR DESCRIPTION
before this commit, search for users on WordPress prior to
version 4.0.0 produced the following error:

PHP Fatal error:  Call to undefined method wpdb::esc_like()

This was due to esc_like being introduced in WordPress 4.0.0.