### PR TITLE
Fix optional parameter declared before required parameter deprecated notice

### DIFF
--- a/group-invites/group-invites.php
+++ b/group-invites/group-invites.php
@@ -369,7 +369,7 @@ class Invite_Anyone_User_Query extends WP_User_Query {
 	}
 }
 
-function get_members_invite_list( $user_id = false, $group_id ) {
+function get_members_invite_list( $user_id, $group_id = 0 ) {
 	global $bp, $wpdb;
 
 	if ( $users = invite_anyone_invite_query( $bp->groups->current_group->id, false, 'ID' ) ) {


### PR DESCRIPTION
This notice shows up on PHP 8 for the `get_members_invite_list()` function.

The `$group_id` parameter is not being used, so could alternatively get rid of this parameter altogether.