### PR TITLE
Group Invites: Only allow members to view 'Send Invites' tab

### DIFF
--- a/group-invites/group-invites.php
+++ b/group-invites/group-invites.php
@@ -97,6 +97,7 @@ class BP_Invite_Anyone extends BP_Group_Extension {
 			'slug'              => BP_INVITE_ANYONE_SLUG,
 			'name'              => __( 'Send Invites', 'invite-anyone' ),
 			'show_tab'          => $this->enable_nav_item(),
+			'access'            => 'member',
 			'nav_item_position' => 71,
 			'screens'           => [
 				'create' => [


### PR DESCRIPTION
When navigating to a group page, the 'Send Invites' tab is showing for logged-out users and logged-in, non-group members.

I believe this bug popped up during BuddyPress 12, but I'm not entirely sure. I think we want to restrict the 'Send Invites' tab to group members only, but we could open this up to authenticated users as well.